### PR TITLE
Remove nopass option for extra security

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -454,7 +454,7 @@ else
 				client=$(sed 's/[^0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-]/_/g' <<< "$unsanitized_client")
 			done
 			cd /etc/openvpn/server/easy-rsa/
-			EASYRSA_CERT_EXPIRE=3650 ./easyrsa build-client-full "$client" nopass
+			EASYRSA_CERT_EXPIRE=3650 ./easyrsa build-client-full "$client"
 			# Generates the custom client.ovpn
 			new_client
 			echo


### PR DESCRIPTION
It is better always to have one extra security level, if someone steal the .ovpn file (like senator's notebook stealled from US Senat for example). So let's create private key passwords by default option.